### PR TITLE
fix:文字コードがlatinになるエラー修正

### DIFF
--- a/db/mysql_cnf/my.cnf
+++ b/db/mysql_cnf/my.cnf
@@ -1,0 +1,7 @@
+[mysql]
+default-character-set=utf8mb4
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+[client]
+default-character-set=utf8mb4

--- a/db/mysql_init/_create.sql
+++ b/db/mysql_init/_create.sql
@@ -1,2 +1,2 @@
-CREATE DATABASE app_name_development;
-CREATE DATABASE app_name_test;
+CREATE DATABASE app_name_development DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE app_name_test DEFAULT CHARACTER SET utf8mb4;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2020_02_25_030142) do
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=latin1", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ./db/mysql_init:/docker-entrypoint-initdb.d
       #永続化するときにマウントするdir
       - ./db/mysql_data:/var/lib/mysql
+      #設定ファイル
+      - .db/mysql_cnf/my.cnf:/etc/mysql/conf.d/my.cnf
 
   web:
     build: .


### PR DESCRIPTION
db/mysql_init/_create.sqlを修正して、最初のDBのcharsetがlatinになるバグを修正しました。
`docker-compose build`時のバグを修正するものなのですでに立ち上げている方は以下のコードを実行してください。
`docker-compose exec web rails db:migrate:reset`